### PR TITLE
chore: dockerfile syntax directive をメジャーバージョン指定に揃える

### DIFF
--- a/servers/reader/Dockerfile
+++ b/servers/reader/Dockerfile
@@ -6,7 +6,7 @@ FROM chef AS planner
 COPY --link . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-FROM bufbuild/buf:1.72.0 as buf
+FROM bufbuild/buf:1.72.0 AS buf
 
 FROM chef AS build-env
 COPY --from=buf --link /usr/local/bin/buf /usr/local/bin/

--- a/servers/reader/Dockerfile
+++ b/servers/reader/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.23
+# syntax=docker/dockerfile:1
 FROM lukemathwalker/cargo-chef:0.1.77-rust-1.97.1 AS chef
 WORKDIR /app
 

--- a/servers/translator/Dockerfile
+++ b/servers/translator/Dockerfile
@@ -6,7 +6,7 @@ FROM chef AS planner
 COPY --link . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-FROM bufbuild/buf:1.72.0 as buf
+FROM bufbuild/buf:1.72.0 AS buf
 
 FROM chef AS build-env
 COPY --from=buf --link /usr/local/bin/buf /usr/local/bin/

--- a/servers/translator/Dockerfile
+++ b/servers/translator/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.23
+# syntax=docker/dockerfile:1
 FROM lukemathwalker/cargo-chef:0.1.77-rust-1.97.1 AS chef
 WORKDIR /app
 


### PR DESCRIPTION
## 概要

`# syntax=docker/dockerfile:1.xx` のようにマイナーバージョンまで固定していた syntax directive を `docker/dockerfile:1` に変更します。

メジャーバージョンのみの指定にすることで、BuildKit が常に最新の 1.x 系 Dockerfile frontend を使うようになり、バージョン更新の追従が不要になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
