### PR TITLE
fix: BSR の廃止済み alpha remote plugins への依存をやめて CI と Docker ビルドを修復する

### DIFF
--- a/.github/workflows/build-and-release-application.yaml
+++ b/.github/workflows/build-and-release-application.yaml
@@ -22,8 +22,11 @@ jobs:
         with:
           # TODO: read from rust-toolchain.toml
           toolchain: "1.97.1"
+          components: rustfmt, clippy
           # キャッシュは後続の Swatinem/rust-cache で行う
           cache: false
+          # デフォルトだと RUSTFLAGS=-D warnings が注入され warning がすべてエラー化してしまう
+          rustflags: ""
 
       # > selecting a toolchain either by action or manual `rustup` calls should happen
       # > before the plugin, as it uses the current rustc version as its cache key
@@ -111,8 +114,11 @@ jobs:
         with:
           # TODO: read from rust-toolchain.toml
           toolchain: "1.97.1"
+          components: rustfmt, clippy
           # キャッシュは後続の Swatinem/rust-cache で行う
           cache: false
+          # デフォルトだと RUSTFLAGS=-D warnings が注入され warning がすべてエラー化してしまう
+          rustflags: ""
 
       # > selecting a toolchain either by action or manual `rustup` calls should happen
       # > before the plugin, as it uses the current rustc version as its cache key

--- a/.github/workflows/build-and-release-application.yaml
+++ b/.github/workflows/build-and-release-application.yaml
@@ -37,14 +37,17 @@ jobs:
 
       # buf CLIがビルドに必要
       - uses: bufbuild/buf-setup-action@v1
+        with:
+          # Dockerfile の bufbuild/buf イメージとバージョンを揃えること
+          version: "1.72.0"
 
       # pbjson-types などのビルドに protoc が必要
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends protobuf-compiler
 
-      # buf generate (build.rs) が使う protoc プラグイン。バージョンは Dockerfile と揃えること
+      # buf generate (build.rs) が使う protoc プラグイン。バージョンはスクリプト内で固定されている
       - name: Install protoc plugins for buf generate
-        run: cargo install protoc-gen-prost@0.2.3 protoc-gen-tonic@0.3.0 protoc-gen-prost-crate@0.3.1
+        run: ./servers/reader/install-buf-plugins.sh
 
       - name: Cargo fmt
         run: cargo fmt --manifest-path servers/reader/Cargo.toml --all -- --check
@@ -129,14 +132,17 @@ jobs:
 
       # buf CLIがビルドに必要
       - uses: bufbuild/buf-setup-action@v1
+        with:
+          # Dockerfile の bufbuild/buf イメージとバージョンを揃えること
+          version: "1.72.0"
 
       # pbjson-types などのビルドに protoc が必要
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends protobuf-compiler
 
-      # buf generate (build.rs) が使う protoc プラグイン。バージョンは Dockerfile と揃えること
+      # buf generate (build.rs) が使う protoc プラグイン。バージョンはスクリプト内で固定されている
       - name: Install protoc plugins for buf generate
-        run: cargo install protoc-gen-prost@0.2.3 protoc-gen-tonic@0.3.0 protoc-gen-prost-crate@0.3.1
+        run: ./servers/translator/install-buf-plugins.sh
 
       - name: Cargo fmt
         run: cargo fmt --manifest-path servers/translator/Cargo.toml --all -- --check

--- a/.github/workflows/build-and-release-application.yaml
+++ b/.github/workflows/build-and-release-application.yaml
@@ -16,19 +16,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      # cargo のエラー/警告の GitHub UI 表示はこの action が登録する problem matcher が行う
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           # TODO: read from rust-toolchain.toml
           toolchain: "1.97.1"
-          profile: "default"
+          # キャッシュは後続の Swatinem/rust-cache で行う
+          cache: false
 
       # > selecting a toolchain either by action or manual `rustup` calls should happen
       # > before the plugin, as it uses the current rustc version as its cache key
       # https://github.com/Swatinem/rust-cache/tree/cb2cf0cc7c5198d3364b9630e2c3d457f160790c#example-usage
       - uses: Swatinem/rust-cache@v2
         with:
-          working-directory: servers/reader
+          workspaces: servers/reader
 
       # buf CLIがビルドに必要
       - uses: bufbuild/buf-setup-action@v1
@@ -41,25 +43,14 @@ jobs:
       - name: Install protoc plugins for buf generate
         run: cargo install protoc-gen-prost@0.2.3 protoc-gen-tonic@0.3.0 protoc-gen-prost-crate@0.3.1
 
-      # GitHubのUIにエラー/警告を表示してくれるので actions-rs/cargo を利用している
-
       - name: Cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path servers/reader/Cargo.toml --all -- --check
+        run: cargo fmt --manifest-path servers/reader/Cargo.toml --all -- --check
 
       - name: Cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path servers/reader/Cargo.toml
+        run: cargo clippy --manifest-path servers/reader/Cargo.toml
 
       - name: Cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path servers/reader/Cargo.toml --all-features
+        run: cargo test --manifest-path servers/reader/Cargo.toml --all-features
 
   reader_build_image:
     name: Build reader docker image (and publish on master)
@@ -114,19 +105,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      # cargo のエラー/警告の GitHub UI 表示はこの action が登録する problem matcher が行う
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           # TODO: read from rust-toolchain.toml
           toolchain: "1.97.1"
-          profile: "default"
+          # キャッシュは後続の Swatinem/rust-cache で行う
+          cache: false
 
       # > selecting a toolchain either by action or manual `rustup` calls should happen
       # > before the plugin, as it uses the current rustc version as its cache key
       # https://github.com/Swatinem/rust-cache/tree/cb2cf0cc7c5198d3364b9630e2c3d457f160790c#example-usage
       - uses: Swatinem/rust-cache@v2
         with:
-          working-directory: servers/translator
+          workspaces: servers/translator
 
       # buf CLIがビルドに必要
       - uses: bufbuild/buf-setup-action@v1
@@ -139,25 +132,14 @@ jobs:
       - name: Install protoc plugins for buf generate
         run: cargo install protoc-gen-prost@0.2.3 protoc-gen-tonic@0.3.0 protoc-gen-prost-crate@0.3.1
 
-      # GitHubのUIにエラー/警告を表示してくれるので actions-rs/cargo を利用している
-
       - name: Cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path servers/translator/Cargo.toml --all -- --check
+        run: cargo fmt --manifest-path servers/translator/Cargo.toml --all -- --check
 
       - name: Cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path servers/translator/Cargo.toml
+        run: cargo clippy --manifest-path servers/translator/Cargo.toml
 
       - name: Cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path servers/translator/Cargo.toml --all-features
+        run: cargo test --manifest-path servers/translator/Cargo.toml --all-features
 
   translator_build_image:
     name: Build translator docker image (and publish on master)

--- a/.github/workflows/build-and-release-application.yaml
+++ b/.github/workflows/build-and-release-application.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           # TODO: read from rust-toolchain.toml
-          toolchain: "1.62.1"
+          toolchain: "1.97.1"
           profile: "default"
 
       # > selecting a toolchain either by action or manual `rustup` calls should happen
@@ -32,6 +32,14 @@ jobs:
 
       # buf CLIがビルドに必要
       - uses: bufbuild/buf-setup-action@v1
+
+      # pbjson-types などのビルドに protoc が必要
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends protobuf-compiler
+
+      # buf generate (build.rs) が使う protoc プラグイン。バージョンは Dockerfile と揃えること
+      - name: Install protoc plugins for buf generate
+        run: cargo install protoc-gen-prost@0.2.3 protoc-gen-tonic@0.3.0 protoc-gen-prost-crate@0.3.1
 
       # GitHubのUIにエラー/警告を表示してくれるので actions-rs/cargo を利用している
 
@@ -110,7 +118,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           # TODO: read from rust-toolchain.toml
-          toolchain: "1.62.1"
+          toolchain: "1.97.1"
           profile: "default"
 
       # > selecting a toolchain either by action or manual `rustup` calls should happen
@@ -122,6 +130,14 @@ jobs:
 
       # buf CLIがビルドに必要
       - uses: bufbuild/buf-setup-action@v1
+
+      # pbjson-types などのビルドに protoc が必要
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends protobuf-compiler
+
+      # buf generate (build.rs) が使う protoc プラグイン。バージョンは Dockerfile と揃えること
+      - name: Install protoc plugins for buf generate
+        run: cargo install protoc-gen-prost@0.2.3 protoc-gen-tonic@0.3.0 protoc-gen-prost-crate@0.3.1
 
       # GitHubのUIにエラー/警告を表示してくれるので actions-rs/cargo を利用している
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ reader / translator のビルド (`cargo build` 等) には、Rust ツールチ�
 - protoc — 依存クレート (pbjson-types など) のビルドに必要です (例: `brew install protobuf`)
 - buf が使う protoc プラグイン — **PATH 上のバイナリがそのまま使われるため、
   バージョン違いのプラグインが入っていると互換性のない生成コードでビルドが壊れます。**
-  必ず同梱のスクリプトでインストールしてください (reader / translator で共通):
+  必ずビルド対象サーバーのスクリプトでインストールしてください
+  (バージョンは各サーバーの依存世代に合わせて独立に管理されています):
 
   ```sh
-  ./servers/reader/install-buf-plugins.sh
+  ./servers/reader/install-buf-plugins.sh      # reader をビルドする場合
+  ./servers/translator/install-buf-plugins.sh  # translator をビルドする場合
   ```

--- a/README.md
+++ b/README.md
@@ -10,3 +10,19 @@
 ## アーキテクチャ俯瞰図
 
 ![architecture](./docs/images/architecture.drawio.svg)
+
+## 開発環境のセットアップ
+
+reader / translator のビルド (`cargo build` 等) には、Rust ツールチェイン (バージョンは各サーバーの
+`rust-toolchain.toml` を参照) に加えて次のツールが必要です。
+
+- [buf CLI](https://buf.build/docs/installation) — build.rs がコード生成に使います
+  (バージョンは Dockerfile の `bufbuild/buf` イメージに揃えることを推奨)
+- protoc — 依存クレート (pbjson-types など) のビルドに必要です (例: `brew install protobuf`)
+- buf が使う protoc プラグイン — **PATH 上のバイナリがそのまま使われるため、
+  バージョン違いのプラグインが入っていると互換性のない生成コードでビルドが壊れます。**
+  必ず同梱のスクリプトでインストールしてください (reader / translator で共通):
+
+  ```sh
+  ./servers/reader/install-buf-plugins.sh
+  ```

--- a/servers/reader/Dockerfile
+++ b/servers/reader/Dockerfile
@@ -1,23 +1,23 @@
 # syntax=docker/dockerfile:1.23
-FROM lukemathwalker/cargo-chef:0.1.35-rust-1.60.0 AS chef
+FROM lukemathwalker/cargo-chef:0.1.77-rust-1.97.1 AS chef
 WORKDIR /app
 
 FROM chef AS planner
 COPY --link . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-FROM bufbuild/buf:1.15.0 as buf
-
-FROM namely/protoc:1.42_2 as protoc
+FROM bufbuild/buf:1.72.0 as buf
 
 FROM chef AS build-env
-COPY --from=planner --link /app/recipe.json recipe.json
 COPY --from=buf --link /usr/local/bin/buf /usr/local/bin/
-COPY --from=protoc --link /usr/local/bin/protoc /usr/local/bin/
 
-# We need these because cargo chef cook will require protoc to build some modules
-ARG PROTOC_NO_VENDOR=true
-ARG PROTOC=/usr/local/bin/protoc
+# We need protoc because cargo chef cook will require it to build some modules (e.g. pbjson-types)
+RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler && rm -rf /var/lib/apt/lists/*
+
+# protoc plugins used by `buf generate` (see buf.gen.yaml); versions must match the CI workflow
+RUN cargo install protoc-gen-prost@0.2.3 protoc-gen-tonic@0.3.0 protoc-gen-prost-crate@0.3.1
+
+COPY --from=planner --link /app/recipe.json recipe.json
 
 # Build dependencies - this is the caching Docker layer!
 RUN cargo chef cook --release --recipe-path recipe.json

--- a/servers/reader/Dockerfile
+++ b/servers/reader/Dockerfile
@@ -14,8 +14,9 @@ COPY --from=buf --link /usr/local/bin/buf /usr/local/bin/
 # We need protoc because cargo chef cook will require it to build some modules (e.g. pbjson-types)
 RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler && rm -rf /var/lib/apt/lists/*
 
-# protoc plugins used by `buf generate` (see buf.gen.yaml); versions must match the CI workflow
-RUN cargo install protoc-gen-prost@0.2.3 protoc-gen-tonic@0.3.0 protoc-gen-prost-crate@0.3.1
+# protoc plugins used by `buf generate` (see buf.gen.yaml); versions are pinned in install-buf-plugins.sh
+COPY --link install-buf-plugins.sh ./
+RUN ./install-buf-plugins.sh
 
 COPY --from=planner --link /app/recipe.json recipe.json
 

--- a/servers/reader/buf.gen.yaml
+++ b/servers/reader/buf.gen.yaml
@@ -1,7 +1,7 @@
 version: v2
 # 各プラグインは crates.io の protoc-gen-prost / protoc-gen-tonic / protoc-gen-prost-crate を
 # ローカルにインストールして使う (BSR のリモートプラグイン実行はレート制限が厳しいため使わない)。
-# インストールするバージョンは CI (build-and-release-application.yaml) と Dockerfile を参照。
+# インストールは同ディレクトリの install-buf-plugins.sh で行う (バージョンはそこで固定)。
 plugins:
   # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-prost#options
   - local: protoc-gen-prost

--- a/servers/reader/buf.gen.yaml
+++ b/servers/reader/buf.gen.yaml
@@ -1,21 +1,24 @@
-version: v1
+version: v2
+# 各プラグインは crates.io の protoc-gen-prost / protoc-gen-tonic / protoc-gen-prost-crate を
+# ローカルにインストールして使う (BSR のリモートプラグイン実行はレート制限が厳しいため使わない)。
+# インストールするバージョンは CI (build-and-release-application.yaml) と Dockerfile を参照。
 plugins:
-  - remote: buf.build/prost/plugins/prost:v0.1.3-2
+  # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-prost#options
+  - local: protoc-gen-prost
     out: src/gen
-    # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-prost#options
     opt:
       - bytes=.
       - compile_well_known_types
       - extern_path=.google.protobuf=::pbjson_types
       - file_descriptor_set
-  - remote: buf.build/prost/plugins/tonic:v0.1.0-2
+  # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-tonic
+  - local: protoc-gen-tonic
     out: src/gen
-    # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-tonic
     opt:
       - compile_well_known_types
       - extern_path=.google.protobuf=::pbjson_types
-  - remote: buf.build/prost/plugins/crate:v0.1.5-2
+  # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-prost-crate
+  - local: protoc-gen-prost-crate
     out: src/gen
-    # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-prost-crate
     opt:
       - no_features

--- a/servers/reader/install-buf-plugins.sh
+++ b/servers/reader/install-buf-plugins.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# buf generate (build.rs) が使う protoc プラグインを固定バージョンでインストールする。
+# CI・Dockerfile・開発環境で同じ生成結果になるよう、バージョン変更は必ずこのスクリプトだけで行うこと。
+# (バージョンは Cargo.toml の prost / tonic の世代と互換である必要がある)
+set -eu
+
+exec cargo install --locked \
+  protoc-gen-prost@0.2.3 \
+  protoc-gen-tonic@0.3.0 \
+  protoc-gen-prost-crate@0.3.1

--- a/servers/reader/rust-toolchain.toml
+++ b/servers/reader/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.62.1"
+channel = "1.97.1"
 profile = "default"

--- a/servers/translator/Dockerfile
+++ b/servers/translator/Dockerfile
@@ -1,23 +1,23 @@
 # syntax=docker/dockerfile:1.23
-FROM lukemathwalker/cargo-chef:0.1.35-rust-1.60.0 AS chef
+FROM lukemathwalker/cargo-chef:0.1.77-rust-1.97.1 AS chef
 WORKDIR /app
 
 FROM chef AS planner
 COPY --link . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-FROM bufbuild/buf:1.15.0 as buf
-
-FROM namely/protoc:1.42_2 as protoc
+FROM bufbuild/buf:1.72.0 as buf
 
 FROM chef AS build-env
-COPY --from=planner --link /app/recipe.json recipe.json
 COPY --from=buf --link /usr/local/bin/buf /usr/local/bin/
-COPY --from=protoc --link /usr/local/bin/protoc /usr/local/bin/
 
-# We need these because cargo chef cook will require protoc to build some modules
-ARG PROTOC_NO_VENDOR=true
-ARG PROTOC=/usr/local/bin/protoc
+# We need protoc because cargo chef cook will require it to build some modules (e.g. pbjson-types)
+RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler && rm -rf /var/lib/apt/lists/*
+
+# protoc plugins used by `buf generate` (see buf.gen.yaml); versions must match the CI workflow
+RUN cargo install protoc-gen-prost@0.2.3 protoc-gen-tonic@0.3.0 protoc-gen-prost-crate@0.3.1
+
+COPY --from=planner --link /app/recipe.json recipe.json
 
 # Build dependencies - this is the caching Docker layer!
 RUN cargo chef cook --release --recipe-path recipe.json

--- a/servers/translator/Dockerfile
+++ b/servers/translator/Dockerfile
@@ -14,8 +14,9 @@ COPY --from=buf --link /usr/local/bin/buf /usr/local/bin/
 # We need protoc because cargo chef cook will require it to build some modules (e.g. pbjson-types)
 RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler && rm -rf /var/lib/apt/lists/*
 
-# protoc plugins used by `buf generate` (see buf.gen.yaml); versions must match the CI workflow
-RUN cargo install protoc-gen-prost@0.2.3 protoc-gen-tonic@0.3.0 protoc-gen-prost-crate@0.3.1
+# protoc plugins used by `buf generate` (see buf.gen.yaml); versions are pinned in install-buf-plugins.sh
+COPY --link install-buf-plugins.sh ./
+RUN ./install-buf-plugins.sh
 
 COPY --from=planner --link /app/recipe.json recipe.json
 

--- a/servers/translator/buf.gen.yaml
+++ b/servers/translator/buf.gen.yaml
@@ -1,7 +1,7 @@
 version: v2
 # 各プラグインは crates.io の protoc-gen-prost / protoc-gen-tonic / protoc-gen-prost-crate を
 # ローカルにインストールして使う (BSR のリモートプラグイン実行はレート制限が厳しいため使わない)。
-# インストールするバージョンは CI (build-and-release-application.yaml) と Dockerfile を参照。
+# インストールは同ディレクトリの install-buf-plugins.sh で行う (バージョンはそこで固定)。
 plugins:
   # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-prost#options
   - local: protoc-gen-prost

--- a/servers/translator/buf.gen.yaml
+++ b/servers/translator/buf.gen.yaml
@@ -1,22 +1,25 @@
-version: v1
+version: v2
+# 各プラグインは crates.io の protoc-gen-prost / protoc-gen-tonic / protoc-gen-prost-crate を
+# ローカルにインストールして使う (BSR のリモートプラグイン実行はレート制限が厳しいため使わない)。
+# インストールするバージョンは CI (build-and-release-application.yaml) と Dockerfile を参照。
 plugins:
-  - remote: buf.build/prost/plugins/prost:v0.1.3-2
+  # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-prost#options
+  - local: protoc-gen-prost
     out: src/gen
-    # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-prost#options
     opt:
       - bytes=.
       - compile_well_known_types
       - extern_path=.google.protobuf=::pbjson_types
       - file_descriptor_set
-  - remote: buf.build/prost/plugins/tonic:v0.2.1-1
+  # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-tonic
+  - local: protoc-gen-tonic
     out: src/gen
-    # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-tonic
     opt:
       - no_server=true
       - compile_well_known_types
       - extern_path=.google.protobuf=::pbjson_types
-  - remote: buf.build/prost/plugins/crate:v0.1.5-2
+  # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-prost-crate
+  - local: protoc-gen-prost-crate
     out: src/gen
-    # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-prost-crate
     opt:
       - no_features

--- a/servers/translator/install-buf-plugins.sh
+++ b/servers/translator/install-buf-plugins.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# buf generate (build.rs) が使う protoc プラグインを固定バージョンでインストールする。
+# CI・Dockerfile・開発環境で同じ生成結果になるよう、バージョン変更は必ずこのスクリプトだけで行うこと。
+# (バージョンは Cargo.toml の prost / tonic の世代と互換である必要がある)
+set -eu
+
+exec cargo install --locked \
+  protoc-gen-prost@0.2.3 \
+  protoc-gen-tonic@0.3.0 \
+  protoc-gen-prost-crate@0.3.1

--- a/servers/translator/rust-toolchain.toml
+++ b/servers/translator/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.62.1"
+channel = "1.97.1"
 profile = "default"

--- a/servers/translator/src/main.rs
+++ b/servers/translator/src/main.rs
@@ -1,6 +1,8 @@
 #![deny(clippy::all, clippy::cargo)]
 #![warn(clippy::nursery, clippy::pedantic)]
 #![allow(clippy::cargo_common_metadata)]
+// 依存クレート同士が同一クレートの別バージョンに依存しているため、このクレートからは解消できない
+#![allow(clippy::multiple_crate_versions)]
 
 mod domain {
     use anyhow::anyhow;
@@ -231,9 +233,12 @@ mod infra_axum_handlers {
 
 mod infra_repository_impls {
     #[allow(dead_code)]
-    #[allow(clippy::nursery, clippy::pedantic)]
+    #[allow(
+        clippy::nursery,
+        clippy::pedantic,
+        clippy::derive_partial_eq_without_eq
+    )]
     mod buf_generated {
-        #![allow(clippy::derive_partial_eq_without_eq)]
         include!("gen/mod.rs");
     }
 


### PR DESCRIPTION
## 背景

master の CI (`Lint and test reader` / `Lint and test translator`) は、`buf.gen.yaml` が参照している BSR の alpha remote plugins (`buf.build/prost/plugins/*`) が廃止されたことにより、少なくとも 2026-05 以降ずっと失敗し続けています。

```
Failure: decode buf.gen.yaml: invalid as version v1: could not unmarshal as YAML:
  line 3: field remote not found in type bufconfig.externalGeneratePluginConfigV1
```

さらに調査の過程で、CI が落ち続けている間に以下の問題も蓄積していたことが分かったため、まとめて修正しています。

## 変更内容

### buf.gen.yaml: 廃止済み remote plugins → crates.io プラグインのローカル実行 (v2 設定)

後継の community remote plugins (`buf.build/community/neoeinstein-*`) への移行も検証しましたが、BSR のリモートプラグイン実行は[未認証だと 10 リクエスト/時/IP のレート制限](https://buf.build/docs/bsr/rate-limits/)があり、egress IP を共有する GitHub ホストランナーでは恒常的に 429 を踏むリスクがあります(検証中に実際にレート制限に到達しました)。そのため、crates.io の `protoc-gen-prost@0.2.3` / `protoc-gen-tonic@0.3.0` / `protoc-gen-prost-crate@0.3.1` を CI と Dockerfile 内にインストールしてローカル実行する構成にしています。バージョンは Cargo.toml の prost 0.11 / tonic 0.9 世代に合わせています。

### Rust 1.62.1 → 1.97.1

Renovate によるロックファイル更新で `Cargo.lock` が lock file version 4 になっており、1.78 未満の cargo では読めません。CI の `actions-rs/toolchain` は default 切り替えを行わないため実際にはランナーの最新 stable でビルドされ続けており(だから CI 上は lock v4 でも動いていた)、`rust-toolchain.toml` の 1.62.1 が効く Docker ビルドだけが壊れている状態でした。`rust-toolchain.toml` / CI / Dockerfile を 1.97.1 に統一しています。

### Dockerfile の現行化

- `lukemathwalker/cargo-chef:0.1.35-rust-1.60.0` → `0.1.77-rust-1.97.1`
- `bufbuild/buf:1.15.0` → `1.72.0` (v2 設定の読み込みに必要)
- amd64 専用の `namely/protoc:1.42_2` を廃止し、apt の `protobuf-compiler` に置換 (Apple Silicon などの arm64 ホストでもビルド可能に)
- プラグインの `cargo install` は recipe.json のコピーより前に配置し、依存変更でレイヤーキャッシュが無効化されないようにしています

### 新しい clippy で顕在化したエラーの修正 (translator)

- `mixed_attributes_style`: `mod buf_generated` の inner/outer 属性混在を outer に統一
- `multiple_crate_versions`: tonic 0.9 が axum 0.6 を引き込む等、依存ツリー由来でこのクレートからは解消できないため crate レベルで allow

## 動作確認

すべて手元 (macOS / Apple Silicon) で確認済みです。

- `cargo fmt --check` / `cargo clippy` (エラー 0) / `cargo test`: reader・translator とも Rust 1.97.1 で通過
- `container build` (apple/container CLI): reader・translator とも linux/arm64 イメージのビルドに成功
- スモークラン: reader は正常終了 (exit 0)、translator はダミーの gRPC エンドポイント指定で期待どおり接続タイムアウトのエラーを出して終了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
